### PR TITLE
Add unit tests and requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pytest
+pandas
+ta
+python-binance
+requests

--- a/tests/test_coin_utils.py
+++ b/tests/test_coin_utils.py
@@ -1,0 +1,38 @@
+import os
+import sys
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'deneysel trade bot v2')))
+
+import coin_utils
+import config
+
+
+def test_get_top_symbols(monkeypatch):
+    fake_exchange = {
+        'symbols': [
+            {'symbol': 'AAAUSDT', 'status': 'TRADING', 'quoteAsset': 'USDT'},
+            {'symbol': 'BBBUSDT', 'status': 'BREAK', 'quoteAsset': 'USDT'},
+            {'symbol': 'CCCBTC', 'status': 'TRADING', 'quoteAsset': 'BTC'},
+            {'symbol': 'EXCUSDT', 'status': 'TRADING', 'quoteAsset': 'USDT'},
+        ]
+    }
+
+    def mock_get_exchange_info():
+        return fake_exchange
+
+    def mock_get_ticker(symbol):
+        if symbol == 'AAAUSDT':
+            return {'quoteVolume': '1000'}
+        if symbol == 'EXCUSDT':
+            return {'quoteVolume': '2000'}
+        raise Exception('unexpected symbol')
+
+    monkeypatch.setattr(coin_utils.client, 'get_exchange_info', mock_get_exchange_info)
+    monkeypatch.setattr(coin_utils.client, 'get_ticker', mock_get_ticker)
+    monkeypatch.setattr(config, 'EXCLUDED_SYMBOLS', ['EXCUSDT'])
+
+    result = coin_utils.get_top_symbols(base_currency='USDT', top_n=10)
+    assert result == ['AAAUSDT']

--- a/tests/test_performance_analyzer.py
+++ b/tests/test_performance_analyzer.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import json
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'deneysel trade bot v2')))
+
+import performance_analyzer
+
+
+def test_analyze_performance(tmp_path, capsys, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    history = [
+        {'symbol': 'AAA', 'type': 'BUY', 'price': 10, 'quantity': 1, 'timestamp': 't1'},
+        {'symbol': 'AAA', 'type': 'SELL', 'price': 12, 'quantity': 1, 'timestamp': 't2'},
+        {'symbol': 'BBB', 'type': 'BUY', 'price': 10, 'quantity': 1, 'timestamp': 't3'},
+        {'symbol': 'BBB', 'type': 'SELL', 'price': 8, 'quantity': 1, 'timestamp': 't4'},
+    ]
+    with open('trade_history.json', 'w', encoding='utf-8') as f:
+        json.dump(history, f)
+    performance_analyzer.analyze_performance()
+    out = capsys.readouterr().out
+    assert 'Total PnL: 0.00 USDT' in out
+    assert 'Success Rate: 50.00% (1/2)' in out
+    with open('performance_report.txt', 'r', encoding='utf-8') as f:
+        text = f.read()
+    assert 'AAA: PnL=2.00' in text
+
+
+def test_analyze_performance_no_file(tmp_path, capsys, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    performance_analyzer.analyze_performance()
+    out = capsys.readouterr().out
+    assert 'No trade history found' in out

--- a/tests/test_position_manager.py
+++ b/tests/test_position_manager.py
@@ -1,0 +1,16 @@
+import os
+import sys
+import json
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'deneysel trade bot v2')))
+
+import position_manager
+
+
+def test_load_save_positions(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    data = {'AAA': 'LONG'}
+    position_manager.save_positions(data)
+    assert os.path.exists('positions.json')
+    loaded = position_manager.load_positions()
+    assert loaded == data

--- a/tests/test_risk_management.py
+++ b/tests/test_risk_management.py
@@ -1,0 +1,23 @@
+import os
+import sys
+import pandas as pd
+import ta
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'deneysel trade bot v2')))
+
+import risk_management
+
+
+def test_calculate_atr(monkeypatch):
+    df = pd.DataFrame({
+        'high': [2, 3, 4],
+        'low': [1, 2, 3],
+        'close': [1.5, 2.5, 3.5]
+    })
+    monkeypatch.setattr(risk_management, 'fetch_klines', lambda symbol: df)
+    atr = ta.volatility.average_true_range(df['high'], df['low'], df['close'], window=14).iloc[-1]
+    expected_sl = df['close'].iloc[-1] - atr * 1.5
+    expected_tp = df['close'].iloc[-1] + atr * 1.5
+    sl, tp = risk_management.calculate_atr_stop_loss_take_profit('AAA')
+    assert round(sl, 6) == round(expected_sl, 6)
+    assert round(tp, 6) == round(expected_tp, 6)

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'deneysel trade bot v2')))
+
+import strategies
+
+
+def _mock_df(**kwargs):
+    return pd.DataFrame({k: [v] for k, v in kwargs.items()})
+
+
+def test_generate_signal_buy(monkeypatch):
+    monkeypatch.setattr(strategies, 'fetch_klines', lambda s, tf, limit=100: _mock_df(close=1))
+    buy_df = _mock_df(macd=1, macd_signal=0, close=10, ema=5, volume=200, volume_ma=100,
+                      rsi=20, bb_low=9, bb_high=11)
+    monkeypatch.setattr(strategies, 'apply_indicators', lambda df: buy_df)
+    result = strategies.generate_signal('AAA', ['1h', '4h'])
+    assert result == 'BUY'
+    score = strategies.generate_signal('AAA', ['1h'], return_score=True)
+    assert score > 0
+
+
+def test_generate_signal_sell_and_hold(monkeypatch):
+    monkeypatch.setattr(strategies, 'fetch_klines', lambda s, tf, limit=100: _mock_df(close=1))
+    sell_df = _mock_df(macd=0, macd_signal=1, close=12, ema=15, volume=50, volume_ma=100,
+                       rsi=80, bb_low=9, bb_high=11)
+    buy_df = _mock_df(macd=1, macd_signal=0, close=10, ema=5, volume=200, volume_ma=100,
+                      rsi=20, bb_low=9, bb_high=11)
+
+    def apply(df):
+        # first timeframe -> sell, second -> buy
+        if apply.counter == 0:
+            apply.counter += 1
+            return sell_df
+        return buy_df
+    apply.counter = 0
+    monkeypatch.setattr(strategies, 'apply_indicators', apply)
+    result = strategies.generate_signal('AAA', ['1h', '4h'])
+    assert result == 'HOLD'
+    monkeypatch.setattr(strategies, 'apply_indicators', lambda df: sell_df)
+    assert strategies.generate_signal('AAA', ['1h', '4h']) == 'SELL'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import json
+import builtins
+import types
+
+import pytest
+
+# Add project path with spaces
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'deneysel trade bot v2')))
+
+import utils
+
+
+def test_adjust_quantity_to_lot_size(monkeypatch):
+    def mock_info(symbol):
+        return {'filters': [{'filterType': 'LOT_SIZE', 'stepSize': '0.1'}]}
+    monkeypatch.setattr(utils, 'get_symbol_info', mock_info)
+    assert utils.adjust_quantity_to_lot_size('AAA', 1.26) == 1.2
+
+
+def test_adjust_notional_to_min(monkeypatch):
+    def mock_info_no(symbol):
+        return {'filters': []}
+    monkeypatch.setattr(utils, 'get_symbol_info', mock_info_no)
+    assert utils.adjust_notional_to_min('AAA', 5, 2) == 5
+
+    def mock_info_with(symbol):
+        return {'filters': [{'filterType': 'MIN_NOTIONAL', 'minNotional': '10'}]}
+    monkeypatch.setattr(utils, 'get_symbol_info', mock_info_with)
+    assert utils.adjust_notional_to_min('AAA', 4, 2) == 5.0
+    assert utils.adjust_notional_to_min('AAA', 6, 2) == 6
+
+
+def test_log_and_trade_history(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    utils.log('BUY order: AAA')
+    with open('trade_log.txt', 'r', encoding='utf-8') as f:
+        content = f.read()
+    assert 'BUY order: AAA' in content
+
+    monkeypatch.setattr(utils, 'client', types.SimpleNamespace())
+    # reuse mock get_symbol_info for trade history
+    monkeypatch.setattr(utils, 'get_symbol_info', lambda s: {'filters': [{'filterType': 'LOT_SIZE', 'stepSize': '1'}]})
+    # patch client.create_order to return minimal response
+    utils.client.create_order = lambda **kwargs: {'fills':[{'price': '1'}], 'executedQty': kwargs['quantity']}
+    utils.save_trade_history('AAA', 'BUY', 1.0, 2)
+    with open('trade_history.json', 'r', encoding='utf-8') as f:
+        hist = json.load(f)
+    assert hist[-1]['symbol'] == 'AAA'


### PR DESCRIPTION
## Summary
- add pytest-based unit tests for utility and strategy functions
- cover coin utilities, risk management, and performance analyzer
- include requirements file with needed dependencies

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68504f53e0b0832391d0ef9951c7c1e5