### PR TITLE
Add ATR-based SL/TP enforcement

### DIFF
--- a/deneysel trade bot v2/main.py
+++ b/deneysel trade bot v2/main.py
@@ -77,7 +77,10 @@ def main():
                 profit_ratio = (current_price - buy_price) / buy_price
 
             if signal == "SELL" and position == "LONG":
-                order = place_order(symbol, "SELL", held_qty)
+                sl, tp = calculate_atr_stop_loss_take_profit(symbol)
+                log(f"{symbol} stop_loss: {sl}, take_profit: {tp}")
+                send_telegram_message(f"{symbol} SL: {sl}, TP: {tp}")
+                order = place_order(symbol, "SELL", held_qty, stop_loss=sl, take_profit=tp)
                 positions[symbol] = "SHORT"
                 save_positions(positions)
                 log(f"🔴 SELL signal: {symbol} tüm pozisyon satıldı")
@@ -92,14 +95,20 @@ def main():
 
                 if sell_qty > 0:
                     sell_qty = adjust_quantity_to_lot_size(symbol, sell_qty)
-                    order = place_order(symbol, "SELL", sell_qty)
+                    sl, tp = calculate_atr_stop_loss_take_profit(symbol)
+                    log(f"{symbol} stop_loss: {sl}, take_profit: {tp}")
+                    send_telegram_message(f"{symbol} SL: {sl}, TP: {tp}")
+                    order = place_order(symbol, "SELL", sell_qty, stop_loss=sl, take_profit=tp)
                     positions[symbol] = "LONG"
                     save_positions(positions)
                     log(f"🟡 Kârda kademeli satış: {symbol} %{profit_ratio*100:.1f} kârla {sell_qty} adet")
                     send_telegram_message(f"Kâr satışı: {symbol} at {current_price}, qty: {sell_qty}")
 
             elif signal == "BUY" and position != "LONG":
-                order = place_order(symbol, "BUY", quantity)
+                sl, tp = calculate_atr_stop_loss_take_profit(symbol)
+                log(f"{symbol} stop_loss: {sl}, take_profit: {tp}")
+                send_telegram_message(f"{symbol} SL: {sl}, TP: {tp}")
+                order = place_order(symbol, "BUY", quantity, stop_loss=sl, take_profit=tp)
                 positions[symbol] = "LONG"
                 save_positions(positions)
                 log(f"🟢 BUY order: {symbol} at {current_price}, qty: {quantity}")

--- a/deneysel trade bot v2/utils.py
+++ b/deneysel trade bot v2/utils.py
@@ -60,7 +60,8 @@ def save_trade_history(symbol, side, price, quantity):
     with open("trade_history.json", "w", encoding="utf-8") as f:
         json.dump(history, f, indent=2)
 
-def place_order(symbol, side, quantity):
+def place_order(symbol, side, quantity, stop_loss=None, take_profit=None):
+    """Place a market order and optionally set OCO take-profit and stop-loss."""
     try:
         order = client.create_order(
             symbol=symbol,
@@ -70,6 +71,23 @@ def place_order(symbol, side, quantity):
         )
         print(f"Order placed: {order}")
         save_trade_history(symbol, side, float(order['fills'][0]['price']), float(order['executedQty']))
+
+        if side == 'BUY' and stop_loss and take_profit:
+            try:
+                stop_limit_price = round(stop_loss * 0.995, 6)
+                oco = client.create_oco_order(
+                    symbol=symbol,
+                    side='SELL',
+                    quantity=quantity,
+                    price=str(take_profit),
+                    stopPrice=str(stop_loss),
+                    stopLimitPrice=str(stop_limit_price),
+                    stopLimitTimeInForce='GTC'
+                )
+                print(f"OCO order placed: {oco}")
+            except BinanceAPIException as e:
+                print(f"Binance OCO error: {e}")
+
         return order
     except BinanceAPIException as e:
         print(f"Binance API error: {e}")


### PR DESCRIPTION
## Summary
- compute ATR-based stop loss and take profit before each trade
- place OCO orders to enforce these levels
- log and send these values over Telegram

## Testing
- `python -m py_compile main.py utils.py risk_management.py telegram_notifier.py`

------
https://chatgpt.com/codex/tasks/task_e_68504b84fe18832388a04e0ef1e47a6a