### PR TITLE
Fix duplicate imports

### DIFF
--- a/deneysel trade bot v2/coin_utils.py
+++ b/deneysel trade bot v2/coin_utils.py
@@ -1,8 +1,6 @@
 import config
 from utils import client
 
-import config
-from utils import client
 
 def get_top_symbols(base_currency='USDT', top_n=50):
     exchange_info = client.get_exchange_info()


### PR DESCRIPTION
## Summary
- remove duplicate `import config` and `from utils import client` from `coin_utils.py`
- ran flake8 (fails: command not found)

## Testing
- `flake8 *.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850463e6fdc8323aef2d9fc5d8c99d2