### PR TITLE
Fix load trade history error handling

### DIFF
--- a/deneysel trade bot v2/main.py
+++ b/deneysel trade bot v2/main.py
@@ -18,7 +18,10 @@ def load_trade_history():
     try:
         with open("trade_history.json", "r", encoding="utf-8") as f:
             return json.load(f)
-    except:
+    except (FileNotFoundError, json.JSONDecodeError):
+        return []
+    except Exception as e:
+        log(f"Unexpected error loading trade history: {e}")
         return []
 
 def get_last_buy_price(symbol, history):


### PR DESCRIPTION
## Summary
- handle FileNotFoundError and JSON errors when loading trade history
- log any unexpected exception while reading trade_history.json

## Testing
- `python -m py_compile 'deneysel trade bot v2/main.py'`

------
https://chatgpt.com/codex/tasks/task_e_685043be885c832382d09316680ee407