### PR TITLE
Add tax report feature

### DIFF
--- a/deneysel trade bot v2/config.py
+++ b/deneysel trade bot v2/config.py
@@ -16,6 +16,8 @@ TAKE_PROFIT_PERCENTAGE = 0.02  # %2 kâr al
 
 # Kâr koruma için iz süren zarar kes oranı
 TRAILING_STOP_PERCENTAGE = 0.03  # %3 geriden takip eden zarar kes
+FEE_RATE = 0.001  # %0.1
+
 
 TIMEFRAMES = ['1h', '4h']
 EXCLUDED_SYMBOLS = ['BNBUSDT', 'USDCUSDT']

--- a/deneysel trade bot v2/tax_report.py
+++ b/deneysel trade bot v2/tax_report.py
@@ -1,0 +1,49 @@
+import json
+from datetime import datetime
+import config
+
+FEE_RATE = getattr(config, "FEE_RATE", 0.001)
+
+def generate_tax_report(history_file="trade_history.json"):
+    try:
+        with open(history_file, "r", encoding="utf-8") as f:
+            history = json.load(f)
+    except FileNotFoundError:
+        print("🔍 No trade history found.")
+        return
+
+    positions = {}
+    total_fees = 0.0
+    total_profit = 0.0
+    lines = [f"🧾 Tax Report - {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"]
+
+    for entry in history:
+        symbol = entry["symbol"]
+        action = entry["type"]
+        price = float(entry["price"])
+        qty = float(entry["quantity"])
+        value = price * qty
+        fee = value * FEE_RATE
+        total_fees += fee
+
+        if action == "BUY":
+            positions[symbol] = {"price": price, "qty": qty}
+        elif action == "SELL" and symbol in positions:
+            buy = positions.pop(symbol)
+            pnl = (price - buy["price"]) * qty
+            total_profit += pnl
+            lines.append(
+                f"{symbol}: BUY {buy['qty']} @ {buy['price']} / SELL {qty} @ {price} => PnL {pnl:.2f} USDT"
+            )
+
+    lines.append(f"Total Fees: {total_fees:.2f} USDT")
+    lines.append(f"Net Profit After Fees: {total_profit - total_fees:.2f} USDT")
+
+    report = "\n".join(lines)
+    with open("tax_report.txt", "w", encoding="utf-8") as f:
+        f.write(report)
+
+    print(report)
+
+if __name__ == "__main__":
+    generate_tax_report()

--- a/tests/test_tax_report.py
+++ b/tests/test_tax_report.py
@@ -1,0 +1,27 @@
+import json
+import sys
+from pathlib import Path
+import importlib
+
+PROJECT_DIR = Path(__file__).resolve().parents[1] / 'deneysel trade bot v2'
+sys.path.insert(0, str(PROJECT_DIR))
+
+tax_report = importlib.import_module('tax_report')
+
+
+def test_generate_tax_report(tmp_path, monkeypatch):
+    history = [
+        {"symbol": "BTCUSDT", "type": "BUY", "price": 10000, "quantity": 0.1, "timestamp": "t1"},
+        {"symbol": "BTCUSDT", "type": "SELL", "price": 10500, "quantity": 0.1, "timestamp": "t2"}
+    ]
+    history_file = tmp_path / "history.json"
+    with open(history_file, 'w', encoding='utf-8') as f:
+        json.dump(history, f)
+
+    reports = []
+    monkeypatch.setattr(tax_report, 'FEE_RATE', 0.001)
+    monkeypatch.setattr('builtins.print', lambda msg: reports.append(msg))
+    tax_report.generate_tax_report(str(history_file))
+
+    assert any("Net Profit After Fees" in line for line in reports[0].split('\n'))
+


### PR DESCRIPTION
## Summary
- add `tax_report.py` script to compute trading PnL and fees
- document fee rate in `config.py`
- test tax report generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68506d12837c832387f26a777cde6511