### PR TITLE
Add ML utilities and daily report

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ This repository contains a simple trading bot project.
 ## New Features
 
 The bot now provides helper modules for:
+* `features.py` – prepare machine-learning features from OHLCV data.
+* `ml_model.py` – train a RandomForest model and make predictions.
+* `daily_report.py` – create a daily PnL summary and optionally send it via Telegram.
 
 * `dashboard.py` – a Tkinter GUI displaying open positions and trade history.
 * `backtester.py` – run a basic historical backtest using Binance data.

--- a/deneysel trade bot v2/daily_report.py
+++ b/deneysel trade bot v2/daily_report.py
@@ -1,0 +1,56 @@
+import json
+from collections import defaultdict
+from datetime import datetime, date
+import config
+from telegram_notifier import send_telegram_message
+
+
+def _load_history(path: str = 'trade_history.json'):
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return []
+
+
+def generate_daily_report(path: str = 'trade_history.json'):
+    """Generate daily PnL report and optionally send via Telegram."""
+    history = _load_history(path)
+    today = date.today()
+    day_trades = [h for h in history if datetime.fromisoformat(h['timestamp']).date() == today]
+    if not day_trades:
+        print('No trades for today')
+        return
+
+    positions = {}
+    pnl_per_coin = defaultdict(float)
+
+    for entry in day_trades:
+        symbol = entry['symbol']
+        price = float(entry['price'])
+        qty = float(entry['quantity'])
+        if entry['type'] == 'BUY':
+            positions[symbol] = {'price': price, 'qty': qty}
+        elif entry['type'] == 'SELL' and symbol in positions:
+            buy = positions.pop(symbol)
+            pnl = (price - buy['price']) * buy['qty']
+            pnl_per_coin[symbol] += pnl
+
+    total_pnl = sum(pnl_per_coin.values())
+    best = max(pnl_per_coin.items(), key=lambda x: x[1])[0] if pnl_per_coin else None
+    worst = min(pnl_per_coin.items(), key=lambda x: x[1])[0] if pnl_per_coin else None
+
+    report_lines = [
+        f"Daily Report - {today}",
+        f"Total PnL: {total_pnl:.2f} USDT",
+    ]
+    if best:
+        report_lines.append(f"Best Coin: {best} ({pnl_per_coin[best]:.2f})")
+    if worst:
+        report_lines.append(f"Worst Coin: {worst} ({pnl_per_coin[worst]:.2f})")
+
+    report = "\n".join(report_lines)
+    print(report)
+
+    if config.TELEGRAM_ENABLED:
+        send_telegram_message(report)

--- a/deneysel trade bot v2/features.py
+++ b/deneysel trade bot v2/features.py
@@ -1,0 +1,32 @@
+import pandas as pd
+import ta
+from utils import client
+
+
+def fetch_klines(symbol: str, interval: str = '1h', limit: int = 100) -> pd.DataFrame:
+    """Fetch historical klines from Binance and return as DataFrame."""
+    klines = client.get_klines(symbol=symbol, interval=interval, limit=limit)
+    df = pd.DataFrame(klines, columns=[
+        'timestamp', 'open', 'high', 'low', 'close', 'volume',
+        'close_time', 'quote_asset_volume', 'number_of_trades',
+        'taker_buy_base_asset_volume', 'taker_buy_quote_asset_volume', 'ignore'
+    ])
+    df['close'] = df['close'].astype(float)
+    df['high'] = df['high'].astype(float)
+    df['low'] = df['low'].astype(float)
+    df['volume'] = df['volume'].astype(float)
+    return df
+
+
+def generate_features(symbol: str, interval: str = '1h') -> pd.DataFrame:
+    """Generate ML features such as RSI, MACD and Bollinger bands."""
+    df = fetch_klines(symbol, interval)
+    df['rsi'] = ta.momentum.rsi(df['close'], window=14)
+    df['macd'] = ta.trend.macd(df['close'])
+    df['macd_signal'] = ta.trend.macd_signal(df['close'])
+    bb = ta.volatility.BollingerBands(df['close'])
+    df['bb_high'] = bb.bollinger_hband()
+    df['bb_low'] = bb.bollinger_lband()
+    df['volume_ma'] = df['volume'].rolling(window=20).mean()
+    features = df[['rsi', 'macd', 'macd_signal', 'bb_high', 'bb_low', 'volume', 'volume_ma']].dropna()
+    return features

--- a/deneysel trade bot v2/ml_model.py
+++ b/deneysel trade bot v2/ml_model.py
@@ -1,0 +1,30 @@
+import os
+import joblib
+import pandas as pd
+from sklearn.ensemble import RandomForestClassifier
+
+MODEL_PATH = 'ml_model.pkl'
+
+
+def train_model(features: pd.DataFrame, labels: pd.Series) -> RandomForestClassifier:
+    """Train a RandomForest model using provided features and labels."""
+    model = RandomForestClassifier(n_estimators=100, random_state=42)
+    model.fit(features, labels)
+    joblib.dump(model, MODEL_PATH)
+    return model
+
+
+def load_model() -> RandomForestClassifier | None:
+    """Load a trained model from disk if available."""
+    if os.path.exists(MODEL_PATH):
+        return joblib.load(MODEL_PATH)
+    return None
+
+
+def predict(features: pd.DataFrame, model: RandomForestClassifier | None = None) -> pd.Series:
+    """Predict BUY/SELL/HOLD labels using the trained model."""
+    if model is None:
+        model = load_model()
+    if model is None:
+        raise ValueError('Model not trained')
+    return pd.Series(model.predict(features), index=features.index)


### PR DESCRIPTION
## Summary
- implement feature generation helper for ML models
- add RandomForest-based model utilities
- provide daily PnL reporting with optional Telegram send
- document the new helper modules in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507df679dc83238bd0ebc20db6c73a