### PR TITLE
Implement multi-agent bot architecture with sizing

### DIFF
--- a/deneysel trade bot v2/agent_manager.py
+++ b/deneysel trade bot v2/agent_manager.py
@@ -1,0 +1,31 @@
+from concurrent.futures import ThreadPoolExecutor
+from typing import Dict, List
+
+
+class AgentManager:
+    """Runs multiple agents in parallel and aggregates their signals."""
+
+    def __init__(self, agents: List[object]):
+        self.agents = agents
+
+    def _aggregate_signal(self, symbol: str) -> str:
+        votes = [agent.get_signal(symbol) for agent in self.agents]
+        buy = votes.count('BUY')
+        sell = votes.count('SELL')
+        if buy > sell:
+            return 'BUY'
+        if sell > buy:
+            return 'SELL'
+        return 'HOLD'
+
+    def get_signals(self, symbols: List[str]) -> Dict[str, str]:
+        results: Dict[str, str] = {}
+        with ThreadPoolExecutor(max_workers=len(symbols)) as executor:
+            future_to_symbol = {executor.submit(self._aggregate_signal, s): s for s in symbols}
+            for future in future_to_symbol:
+                symbol = future_to_symbol[future]
+                try:
+                    results[symbol] = future.result()
+                except Exception:
+                    results[symbol] = 'HOLD'
+        return results

--- a/deneysel trade bot v2/agent_ml.py
+++ b/deneysel trade bot v2/agent_ml.py
@@ -1,0 +1,21 @@
+from features import generate_features
+from ml_model import load_model, predict
+
+
+class MLAgent:
+    """Agent that generates trading signals using a machine learning model."""
+
+    def __init__(self):
+        self.model = load_model()
+
+    def get_signal(self, symbol: str) -> str:
+        if self.model is None:
+            return 'HOLD'
+        try:
+            features = generate_features(symbol)
+            if features.empty:
+                return 'HOLD'
+            pred = predict(features.tail(1), self.model)
+            return pred.iloc[0]
+        except Exception:
+            return 'HOLD'

--- a/deneysel trade bot v2/agent_news.py
+++ b/deneysel trade bot v2/agent_news.py
@@ -1,0 +1,6 @@
+class NewsAgent:
+    """Placeholder agent for news-based analysis."""
+
+    def get_signal(self, symbol: str) -> str:
+        # News analysis would normally happen here
+        return 'HOLD'

--- a/deneysel trade bot v2/agent_swing.py
+++ b/deneysel trade bot v2/agent_swing.py
@@ -1,0 +1,9 @@
+import config
+from strategies import generate_signal
+
+
+class SwingAgent:
+    """Agent that uses indicator based swing trading strategy."""
+
+    def get_signal(self, symbol: str) -> str:
+        return generate_signal(symbol, config.TIMEFRAMES)

--- a/deneysel trade bot v2/performance_graphs.py
+++ b/deneysel trade bot v2/performance_graphs.py
@@ -1,0 +1,54 @@
+import json
+import os
+from datetime import datetime
+from typing import List
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+
+def _load_history(path: str) -> List[dict]:
+    if not os.path.exists(path):
+        return []
+    with open(path, 'r', encoding='utf-8') as f:
+        try:
+            return json.load(f)
+        except json.JSONDecodeError:
+            return []
+
+
+def generate_performance_graphs(history_file: str = 'trade_history.json', out_dir: str = 'graphs') -> None:
+    """Create daily/weekly/monthly PnL graphs from trade history."""
+    history = _load_history(history_file)
+    if not history:
+        return
+    data = []
+    positions = {}
+    for entry in history:
+        ts = datetime.fromisoformat(entry['timestamp'])
+        symbol = entry['symbol']
+        side = entry['type']
+        price = float(entry['price'])
+        qty = float(entry['quantity'])
+        if side == 'BUY':
+            positions[symbol] = (price, qty)
+        elif side == 'SELL' and symbol in positions:
+            buy_p, buy_q = positions.pop(symbol)
+            pnl = (price - buy_p) * min(qty, buy_q)
+            data.append({'timestamp': ts, 'pnl': pnl})
+    if not data:
+        return
+    df = pd.DataFrame(data).set_index('timestamp')
+    os.makedirs(out_dir, exist_ok=True)
+    for freq, name in [('D', 'daily'), ('W', 'weekly'), ('M', 'monthly')]:
+        series = df['pnl'].resample(freq).sum().cumsum()
+        if series.empty:
+            continue
+        plt.figure()
+        series.plot()
+        plt.title(f'Cumulative PnL ({name})')
+        plt.xlabel('Date')
+        plt.ylabel('PnL (USDT)')
+        plt.tight_layout()
+        plt.savefig(os.path.join(out_dir, f'pnl_{name}.png'))
+        plt.close()

--- a/deneysel trade bot v2/sizing.py
+++ b/deneysel trade bot v2/sizing.py
@@ -1,0 +1,53 @@
+import pandas as pd
+import numpy as np
+import ta
+from utils import client
+
+
+def fetch_klines(symbol: str, interval: str = '1h', limit: int = 100) -> pd.DataFrame:
+    """Fetch historical klines from Binance."""
+    klines = client.get_klines(symbol=symbol, interval=interval, limit=limit)
+    df = pd.DataFrame(klines, columns=[
+        'timestamp', 'open', 'high', 'low', 'close', 'volume',
+        'close_time', 'quote_asset_volume', 'number_of_trades',
+        'taker_buy_base_asset_volume', 'taker_buy_quote_asset_volume', 'ignore'
+    ])
+    df['close'] = df['close'].astype(float)
+    df['high'] = df['high'].astype(float)
+    df['low'] = df['low'].astype(float)
+    return df
+
+
+def _kelly_fraction(returns: pd.Series) -> float:
+    """Compute Kelly fraction based on win/loss statistics."""
+    if returns.empty:
+        return 0.0
+    win_rate = (returns > 0).mean()
+    win_return = returns[returns > 0].mean()
+    loss_return = -returns[returns < 0].mean()
+    if loss_return == 0 or np.isnan(loss_return):
+        return 0.0
+    win_loss_ratio = win_return / loss_return
+    return win_rate - (1 - win_rate) / win_loss_ratio
+
+
+def calculate_position_size(balance: float, symbol: str, risk_portion: float = 0.1) -> float:
+    """Return position size in base currency using Kelly and volatility factors."""
+    df = fetch_klines(symbol)
+    if df.empty:
+        return 0.0
+
+    price = df['close'].iloc[-1]
+    atr = ta.volatility.average_true_range(df['high'], df['low'], df['close'], window=14).iloc[-1]
+    returns = df['close'].pct_change().dropna()
+
+    sharpe = returns.mean() / returns.std() if returns.std() != 0 else 0.0
+    kelly = _kelly_fraction(returns)
+    kelly = min(max(kelly, 0.0), 1.0)
+
+    vol_pct = atr / price if price else 0.0
+    volatility_factor = 1 - min(vol_pct, 0.9)
+    sharpe_factor = min(max((sharpe + 1) / 2, 0.1), 1.0)
+
+    position_fraction = risk_portion * kelly * volatility_factor * sharpe_factor
+    return balance * max(position_fraction, 0.0)


### PR DESCRIPTION
## Summary
- add parallel agent manager with ML, swing and news agents
- implement Kelly-based position sizing
- track PnL history with performance graphs
- integrate agents and sizing logic in `main.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68510fc9aa848323bf8ae946aacc3648