### PR TITLE
Improve strategy selector logic

### DIFF
--- a/deneysel trade bot v2/main.py
+++ b/deneysel trade bot v2/main.py
@@ -9,7 +9,7 @@ from utils import (
     logger,
 )
 from coin_utils import get_top_symbols
-from strategies import generate_signal
+from strategy_selector import generate_signal
 from risk_management import calculate_atr_stop_loss_take_profit, calculate_trailing_stop
 from telegram_notifier import send_telegram_message
 from utils import client

--- a/deneysel trade bot v2/strategy_selector.py
+++ b/deneysel trade bot v2/strategy_selector.py
@@ -1,0 +1,85 @@
+import strategies
+from features import generate_features
+from ml_model import load_model, predict
+
+
+def volatility_breakout_signal(symbol, timeframes, return_score=False):
+    buy = 0
+    sell = 0
+    for tf in timeframes:
+        df = strategies.fetch_klines(symbol, tf)
+        df['range'] = df['high'].astype(float) - df['low'].astype(float)
+        df['target'] = df['open'].astype(float) + df['range'].shift(1) * 0.5
+        latest = df.iloc[-1]
+        prev_range = df['range'].shift(1).iloc[-1]
+        if latest['close'] > latest['target']:
+            buy += 1
+        elif latest['close'] < float(latest['open']) - prev_range * 0.5:
+            sell += 1
+    if return_score:
+        return buy - sell
+    if buy == len(timeframes):
+        return 'BUY'
+    if sell == len(timeframes):
+        return 'SELL'
+    return 'HOLD'
+
+
+def ml_model_signal(symbol, timeframes, return_score=False):
+    try:
+        features = generate_features(symbol)
+        model = load_model()
+        prediction = predict(features.tail(1), model).iloc[0]
+    except Exception:
+        prediction = 'HOLD'
+    if return_score:
+        mapping = {'BUY': 1, 'SELL': -1, 'HOLD': 0}
+        return mapping.get(prediction, 0)
+    return prediction
+
+
+# Optional overrides for specific symbols. Any entry here will bypass the
+# dynamic selection in ``select_strategy``.
+OVERRIDE_STRATEGY_MAP = {
+    'BTCUSDT': strategies.generate_signal,
+    'PEPEUSDT': volatility_breakout_signal,
+    'DOGEUSDT': ml_model_signal,
+}
+
+
+def select_strategy(symbol):
+    """Choose a strategy for ``symbol`` based on recent volatility.
+
+    Symbols present in :data:`OVERRIDE_STRATEGY_MAP` use the mapped strategy.
+    All other symbols are classified automatically. Highly volatile coins use a
+    volatility breakout approach, low-volatility coins keep the default EMA
+    strategy, and the remainder utilise the ML model.
+    """
+
+    if symbol in OVERRIDE_STRATEGY_MAP:
+        return OVERRIDE_STRATEGY_MAP[symbol]
+
+    try:
+        df = strategies.fetch_klines(symbol, '1h', limit=48)
+        df['close'] = df['close'].astype(float)
+        volatility = df['close'].pct_change().std()
+    except Exception:
+        # On failure fall back to the base strategy
+        return strategies.generate_signal
+
+    if volatility is None:
+        return strategies.generate_signal
+
+    if volatility > 0.05:
+        return volatility_breakout_signal
+    if volatility < 0.02:
+        return strategies.generate_signal
+    return ml_model_signal
+
+
+def generate_signal(symbol, timeframes, return_score=False):
+    """Generate a trading signal for ``symbol`` using its selected strategy."""
+
+    strategy = select_strategy(symbol)
+    return strategy(symbol, timeframes, return_score=return_score)
+

--- a/tests/test_strategy_selector.py
+++ b/tests/test_strategy_selector.py
@@ -1,0 +1,110 @@
+import sys
+import types
+from pathlib import Path
+import importlib
+
+PROJECT_DIR = Path(__file__).resolve().parents[1] / 'deneysel trade bot v2'
+
+
+def load_module(name):
+    spec = importlib.util.spec_from_file_location(name, PROJECT_DIR / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+# Stubs for external deps used in strategy_selector
+sys.modules.setdefault('joblib', types.ModuleType('joblib'))
+sklearn = types.ModuleType('sklearn')
+sklearn.ensemble = types.ModuleType('sklearn.ensemble')
+sklearn.ensemble.RandomForestClassifier = object
+sys.modules.setdefault('sklearn', sklearn)
+sys.modules.setdefault('sklearn.ensemble', sklearn.ensemble)
+
+strategies = load_module('strategies')
+strategy_selector = load_module('strategy_selector')
+
+
+class DummySeries(list):
+    def astype(self, dtype):
+        return DummySeries([dtype(x) for x in self])
+
+    def pct_change(self):
+        result = []
+        prev = None
+        for v in self:
+            if prev is None:
+                result.append(0)
+            else:
+                result.append((v - prev) / prev)
+            prev = v
+        return DummySeries(result)
+
+    def std(self):
+        if not self:
+            return 0
+        mean = sum(self) / len(self)
+        var = sum((x - mean) ** 2 for x in self) / len(self)
+        return var ** 0.5
+
+
+class DummyDataFrame:
+    def __init__(self, closes):
+        self._closes = closes
+
+    def __getitem__(self, key):
+        if key == 'close':
+            return DummySeries(list(self._closes))
+        raise KeyError(key)
+
+    def __setitem__(self, key, value):
+        if key == 'close':
+            self._closes = list(value)
+
+
+def test_override_mapping(monkeypatch):
+    monkeypatch.setattr(strategy_selector, 'volatility_breakout_signal', lambda *a, **k: 'VB')
+    monkeypatch.setattr(strategy_selector, 'ml_model_signal', lambda *a, **k: 'ML')
+    monkeypatch.setattr(strategies, 'generate_signal', lambda *a, **k: 'DEF')
+
+    strategy_selector.OVERRIDE_STRATEGY_MAP = {'AAAUSDT': lambda *a, **k: 'OVR'}
+
+    result = strategy_selector.generate_signal('AAAUSDT', ['1h'])
+    assert result == 'OVR'
+
+
+def test_high_volatility(monkeypatch):
+    monkeypatch.setattr(strategy_selector, 'volatility_breakout_signal', lambda *a, **k: 'VB')
+    monkeypatch.setattr(strategy_selector, 'ml_model_signal', lambda *a, **k: 'ML')
+    monkeypatch.setattr(strategies, 'generate_signal', lambda *a, **k: 'DEF')
+
+    monkeypatch.setattr(strategy_selector, 'OVERRIDE_STRATEGY_MAP', {})
+    monkeypatch.setattr(strategies, 'fetch_klines', lambda symbol, tf, limit=48: DummyDataFrame([1, 2, 1, 3, 1]))
+
+    result = strategy_selector.generate_signal('TEST', ['1h'])
+    assert result == 'VB'
+
+
+def test_low_volatility(monkeypatch):
+    monkeypatch.setattr(strategy_selector, 'volatility_breakout_signal', lambda *a, **k: 'VB')
+    monkeypatch.setattr(strategy_selector, 'ml_model_signal', lambda *a, **k: 'ML')
+    monkeypatch.setattr(strategies, 'generate_signal', lambda *a, **k: 'DEF')
+
+    monkeypatch.setattr(strategy_selector, 'OVERRIDE_STRATEGY_MAP', {})
+    monkeypatch.setattr(strategies, 'fetch_klines', lambda symbol, tf, limit=48: DummyDataFrame([1]*5))
+
+    result = strategy_selector.generate_signal('TEST', ['1h'])
+    assert result == 'DEF'
+
+
+def test_medium_volatility(monkeypatch):
+    monkeypatch.setattr(strategy_selector, 'volatility_breakout_signal', lambda *a, **k: 'VB')
+    monkeypatch.setattr(strategy_selector, 'ml_model_signal', lambda *a, **k: 'ML')
+    monkeypatch.setattr(strategies, 'generate_signal', lambda *a, **k: 'DEF')
+
+    monkeypatch.setattr(strategy_selector, 'OVERRIDE_STRATEGY_MAP', {})
+    monkeypatch.setattr(strategies, 'fetch_klines', lambda symbol, tf, limit=48: DummyDataFrame([1, 1.02, 0.98, 1.01, 0.99]))
+
+    result = strategy_selector.generate_signal('TEST', ['1h'])
+    assert result == 'ML'
+


### PR DESCRIPTION
## Summary
- introduce dynamic strategy selection based on volatility
- override individual coins via `OVERRIDE_STRATEGY_MAP`
- update tests for the selector logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68510f8d10cc832399e0352c23d95070