### PR TITLE
Add advanced trading utilities and Telegram command bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ The bot now provides helper modules for:
 * `position_manager.py` – keeps track of last exit times to allow re-entry checks.
 * `utils.py` – includes retry logic for orders, partial sell support, and daily trade limit checks.
 
+Additional helper modules include:
+* `bot_command_handler.py` – polling Telegram bot for `/status`, `/pnl`, `/pause` and `/resume` commands.
+* `regime_detector.py` – determine if the market is trending or ranging.
+* `walk_forward.py` – perform walk-forward validation of machine-learning models.
+* `paper_trade.py` – simulate trades without sending real orders.
+* `metrics_db.py` – store trade and PnL metrics in a SQLite database.
+* `healthcheck.py` – basic health monitor that can restart the bot.
+* `autotune.py` – run a small grid search to find the best ML hyperparameters.
+
 
 ## Running Tests
 

--- a/deneysel trade bot v2/autotune.py
+++ b/deneysel trade bot v2/autotune.py
@@ -1,0 +1,20 @@
+import json
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import GridSearchCV
+
+
+BEST_PARAMS_FILE = "best_model_params.json"
+
+
+def autotune(X, y) -> dict:
+    """Run a small grid search and save best parameters."""
+    param_grid = {
+        "n_estimators": [50, 100],
+        "max_depth": [None, 5, 10],
+    }
+    search = GridSearchCV(RandomForestClassifier(), param_grid, cv=3)
+    search.fit(X, y)
+    best_params = search.best_params_
+    with open(BEST_PARAMS_FILE, "w", encoding="utf-8") as f:
+        json.dump(best_params, f, indent=2)
+    return best_params

--- a/deneysel trade bot v2/bot_command_handler.py
+++ b/deneysel trade bot v2/bot_command_handler.py
@@ -1,0 +1,70 @@
+import os
+import time
+import requests
+import json
+
+import config
+from utils import get_balance
+from position_manager import load_positions
+from performance_analyzer import analyze_performance
+from telegram_notifier import send_telegram_message
+
+API_URL = f"https://api.telegram.org/bot{config.TELEGRAM_TOKEN}"
+OFFSET_FILE = "telegram_offset.txt"
+PAUSE_FLAG = "paused.flag"
+
+
+def _get_offset() -> int:
+    if os.path.exists(OFFSET_FILE):
+        with open(OFFSET_FILE, "r", encoding="utf-8") as f:
+            try:
+                return int(f.read().strip())
+            except ValueError:
+                return 0
+    return 0
+
+
+def _save_offset(offset: int) -> None:
+    with open(OFFSET_FILE, "w", encoding="utf-8") as f:
+        f.write(str(offset))
+
+
+def _handle_command(command: str) -> str:
+    if command == "/status":
+        balance = get_balance(config.BASE_CURRENCY)
+        positions = load_positions()
+        return f"Balance: {balance} {config.BASE_CURRENCY}\nPositions: {json.dumps(positions)}"
+    if command == "/pnl":
+        report = analyze_performance()
+        return report or "No trade history"
+    if command == "/pause":
+        open(PAUSE_FLAG, "w").close()
+        return "Bot paused"
+    if command == "/resume":
+        if os.path.exists(PAUSE_FLAG):
+            os.remove(PAUSE_FLAG)
+        return "Bot resumed"
+    return "Unknown command"
+
+
+def poll_commands(sleep_time: int = 5) -> None:
+    """Continuously poll Telegram for new commands and respond."""
+    offset = _get_offset()
+    while True:
+        try:
+            resp = requests.get(f"{API_URL}/getUpdates", params={"timeout": 30, "offset": offset + 1})
+            data = resp.json()
+            if not data.get("ok"):
+                time.sleep(sleep_time)
+                continue
+            for result in data.get("result", []):
+                offset = result["update_id"]
+                message = result.get("message", {})
+                text = message.get("text", "")
+                if text.startswith("/"):
+                    reply = _handle_command(text.strip())
+                    send_telegram_message(reply)
+            _save_offset(offset)
+        except Exception as exc:  # pragma: no cover - network issues
+            print(f"Telegram polling error: {exc}")
+        time.sleep(sleep_time)

--- a/deneysel trade bot v2/healthcheck.py
+++ b/deneysel trade bot v2/healthcheck.py
@@ -1,0 +1,22 @@
+import os
+import time
+import requests
+
+CHECK_INTERVAL = 300
+TARGET_URL = "https://api.binance.com/api/v3/time"
+
+
+def is_alive() -> bool:
+    try:
+        requests.get(TARGET_URL, timeout=10)
+        return True
+    except Exception:
+        return False
+
+
+def monitor_and_restart(cmd: str) -> None:
+    while True:
+        if not is_alive():  # pragma: no cover - network
+            print("Health check failed, restarting bot...")
+            os.system(cmd)
+        time.sleep(CHECK_INTERVAL)

--- a/deneysel trade bot v2/metrics_db.py
+++ b/deneysel trade bot v2/metrics_db.py
@@ -1,0 +1,37 @@
+import sqlite3
+from contextlib import closing
+from datetime import datetime
+
+DB_PATH = "metrics.db"
+
+
+def init_db() -> None:
+    with closing(sqlite3.connect(DB_PATH)) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "CREATE TABLE IF NOT EXISTS trades (symbol TEXT, side TEXT, price REAL, qty REAL, ts TEXT)"
+        )
+        cur.execute(
+            "CREATE TABLE IF NOT EXISTS pnl (symbol TEXT, pnl REAL, ts TEXT)"
+        )
+        conn.commit()
+
+
+def log_trade(symbol: str, side: str, price: float, qty: float) -> None:
+    ts = datetime.now().isoformat()
+    with closing(sqlite3.connect(DB_PATH)) as conn:
+        conn.execute(
+            "INSERT INTO trades (symbol, side, price, qty, ts) VALUES (?,?,?,?,?)",
+            (symbol, side, price, qty, ts),
+        )
+        conn.commit()
+
+
+def log_pnl(symbol: str, pnl: float) -> None:
+    ts = datetime.now().isoformat()
+    with closing(sqlite3.connect(DB_PATH)) as conn:
+        conn.execute(
+            "INSERT INTO pnl (symbol, pnl, ts) VALUES (?,?,?)",
+            (symbol, pnl, ts),
+        )
+        conn.commit()

--- a/deneysel trade bot v2/paper_trade.py
+++ b/deneysel trade bot v2/paper_trade.py
@@ -1,0 +1,36 @@
+import json
+from datetime import datetime
+
+TRADE_HISTORY = "paper_trade_history.json"
+
+
+def paper_place_order(symbol: str, side: str, quantity: float, price: float) -> None:
+    """Record a simulated trade to the paper trade history."""
+    entry = {
+        "symbol": symbol,
+        "type": side,
+        "price": price,
+        "quantity": quantity,
+        "timestamp": datetime.now().isoformat(),
+    }
+
+    history = []
+    try:
+        with open(TRADE_HISTORY, "r", encoding="utf-8") as f:
+            history = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        history = []
+
+    history.append(entry)
+    with open(TRADE_HISTORY, "w", encoding="utf-8") as f:
+        json.dump(history, f, indent=2)
+
+
+class PaperBroker:
+    """A simple broker that simulates order fills."""
+
+    def market_buy(self, symbol: str, quantity: float, price: float) -> None:
+        paper_place_order(symbol, "BUY", quantity, price)
+
+    def market_sell(self, symbol: str, quantity: float, price: float) -> None:
+        paper_place_order(symbol, "SELL", quantity, price)

--- a/deneysel trade bot v2/performance_analyzer.py
+++ b/deneysel trade bot v2/performance_analyzer.py
@@ -62,3 +62,5 @@ def analyze_performance():
 
     if config.TELEGRAM_ENABLED:
         send_telegram_message(report)
+
+    return report

--- a/deneysel trade bot v2/regime_detector.py
+++ b/deneysel trade bot v2/regime_detector.py
@@ -1,0 +1,42 @@
+import pandas as pd
+import numpy as np
+
+from utils import client
+
+
+def fetch_close(symbol: str, interval: str = "1h", limit: int = 200) -> pd.DataFrame:
+    klines = client.get_klines(symbol=symbol, interval=interval, limit=limit)
+    df = pd.DataFrame(klines, columns=[
+        "timestamp", "open", "high", "low", "close", "volume",
+        "close_time", "qav", "trades", "tbav", "tqav", "ignore"
+    ])
+    df[["high", "low", "close"]] = df[["high", "low", "close"]].astype(float)
+    return df
+
+
+def bollinger_band_width(close: pd.Series, window: int = 20) -> pd.Series:
+    ma = close.rolling(window).mean()
+    std = close.rolling(window).std()
+    upper = ma + 2 * std
+    lower = ma - 2 * std
+    width = (upper - lower) / ma
+    return width
+
+
+def detect_market_regime(df: pd.DataFrame) -> str:
+    """Return 'TREND' or 'RANGE' based on simple metrics."""
+    if len(df) < 20:
+        return "UNKNOWN"
+
+    width = bollinger_band_width(df["close"])
+    slope = (df["close"].iloc[-1] - df["close"].iloc[0]) / len(df)
+    adx_like = (df["high"].diff().abs() - df["low"].diff().abs()).abs().rolling(14).mean().iloc[-1]
+
+    if width.iloc[-1] < width.mean() and abs(slope) < adx_like:
+        return "RANGE"
+    return "TREND"
+
+
+if __name__ == "__main__":  # pragma: no cover - manual usage
+    d = fetch_close("BTCUSDT")
+    print(detect_market_regime(d))

--- a/deneysel trade bot v2/walk_forward.py
+++ b/deneysel trade bot v2/walk_forward.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import pandas as pd
+from sklearn.metrics import accuracy_score
+
+
+def walk_forward(model, data: pd.DataFrame, label_column: str, train_size: int = 100, test_size: int = 20) -> list[float]:
+    """Simple walk-forward validation returning accuracy scores."""
+    scores = []
+    start = 0
+    while start + train_size + test_size <= len(data):
+        train = data.iloc[start:start + train_size]
+        test = data.iloc[start + train_size:start + train_size + test_size]
+        X_train = train.drop(label_column, axis=1)
+        y_train = train[label_column]
+        X_test = test.drop(label_column, axis=1)
+        y_test = test[label_column]
+
+        model.fit(X_train, y_train)
+        preds = model.predict(X_test)
+        scores.append(accuracy_score(y_test, preds))
+        start += test_size
+    return scores


### PR DESCRIPTION
## Summary
- enable `performance_analyzer.analyze_performance` to return report text
- add polling based `bot_command_handler` for status, pnl and pause commands
- implement market regime detection helper
- provide walk-forward validation utilities
- add simple paper trading broker
- support centralized metrics storage via SQLite
- add health check and restart script
- include hyperparameter auto tuning helper
- document new modules in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851244df51c83239235af804f8f6525