### PR TITLE
Add GUI launcher for config and exe build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,22 @@ pytest
 ```
 
 This command will discover and run all tests inside the `tests/` directory.
+
+## GUI Launcher
+
+A simple Tkinter utility `gui_launcher.py` allows you to enter common configuration
+parameters such as API keys and trade size before starting the bot. Run it with:
+
+```bash
+python gui_launcher.py
+```
+
+To build a standalone executable on Windows, install [PyInstaller](https://pyinstaller.org)
+and execute:
+
+```bash
+pyinstaller --onefile gui_launcher.py
+```
+
+The resulting binary will be placed in the `dist/` directory and can be run with a
+single click.

--- a/deneysel trade bot v2/gui_launcher.py
+++ b/deneysel trade bot v2/gui_launcher.py
@@ -1,0 +1,82 @@
+import tkinter as tk
+from tkinter import ttk
+
+import config
+import main
+
+
+class ConfigField:
+    def __init__(self, root, label, default=""):
+        ttk.Label(root, text=label).pack(anchor="w")
+        self.var = tk.StringVar(value=default)
+        ttk.Entry(root, textvariable=self.var, width=40).pack(fill="x")
+
+    def get(self):
+        return self.var.get().strip()
+
+
+def start_bot(fields, root):
+    config.BINANCE_API_KEY = fields["api_key"].get()
+    config.BINANCE_API_SECRET = fields["api_secret"].get()
+    config.TELEGRAM_TOKEN = fields["telegram_token"].get()
+    config.TELEGRAM_CHAT_ID = fields["telegram_chat_id"].get()
+    base_currency = fields["base_currency"].get()
+    if base_currency:
+        config.BASE_CURRENCY = base_currency
+
+    try:
+        trade_pct = fields["trade_percentage"].get()
+        if trade_pct:
+            config.TRADE_PERCENTAGE = float(trade_pct)
+    except ValueError:
+        pass
+
+    try:
+        min_trade = fields["min_trade_amount"].get()
+        if min_trade:
+            config.MIN_TRADE_AMOUNT = float(min_trade)
+    except ValueError:
+        pass
+
+    try:
+        interval = fields["check_interval"].get()
+        if interval:
+            config.CHECK_INTERVAL = int(interval)
+    except ValueError:
+        pass
+
+    tfs = fields["timeframes"].get()
+    if tfs:
+        config.TIMEFRAMES = [t.strip() for t in tfs.split(",") if t.strip()]
+
+    root.destroy()
+    main.main()
+
+
+def main_gui():
+    root = tk.Tk()
+    root.title("TradeBot Launcher")
+
+    fields = {
+        "api_key": ConfigField(root, "Binance API Key", config.BINANCE_API_KEY),
+        "api_secret": ConfigField(root, "Binance API Secret", config.BINANCE_API_SECRET),
+        "telegram_token": ConfigField(root, "Telegram Token", config.TELEGRAM_TOKEN),
+        "telegram_chat_id": ConfigField(root, "Telegram Chat ID", config.TELEGRAM_CHAT_ID),
+        "base_currency": ConfigField(root, "Base Currency", config.BASE_CURRENCY),
+        "trade_percentage": ConfigField(root, "Trade Percentage", str(config.TRADE_PERCENTAGE)),
+        "min_trade_amount": ConfigField(root, "Min Trade Amount", str(config.MIN_TRADE_AMOUNT)),
+        "check_interval": ConfigField(root, "Check Interval (s)", str(config.CHECK_INTERVAL)),
+        "timeframes": ConfigField(root, "Timeframes (comma separated)", ",".join(config.TIMEFRAMES)),
+    }
+
+    ttk.Button(
+        root,
+        text="Start Bot",
+        command=lambda: start_bot(fields, root)
+    ).pack(pady=10)
+
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main_gui()


### PR DESCRIPTION
## Summary
- add a simple Tkinter GUI (`gui_launcher.py`) to set basic config parameters and run the bot
- document how to use the launcher and build a Windows executable with PyInstaller

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68512db15ae88323a89b11b64e3f37d4